### PR TITLE
Flow excluder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquaman-redux",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Redux middlewear for composable, declarative control flow",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -1,5 +1,15 @@
-import { AquamanStep } from './Types';
+import { AquamanStep } from "./Types";
 
+/**
+ * Dispatch to step forward in the current flow.
+ *
+ * If current step is last step in flow, the flow will end and `onEndFlow`
+ * configuration will be called;
+ *
+ * @param data any value to be passed to action series's next step.
+ * If branching, use integers which correspond the index of desired branch.
+ * @returns Redux action of type `__Aquaman_NEXT__`
+ */
 export const aquamanNext = (
   data?: any
 ): {
@@ -9,19 +19,42 @@ export const aquamanNext = (
   type: AquamanStep.NEXT,
   data,
 });
+
+/**
+ * Dispatch to step backward through the current flow.
+ *
+ * @returns Redux action of type `__Aquaman_PREVIOUS__`
+ */
 export const aquamanPrevious = (): {
   type: AquamanStep.PREVIOUS;
 } => ({
   type: AquamanStep.PREVIOUS,
 });
+
+/**
+ * Dispatch to immediately end the current flow and call `onEndFlow` configuration.
+ *
+ * @returns Redux action of type `__Aquaman_CLOSE__`
+ */
 export const aquamanClose = (): {
   type: AquamanStep.CLOSE;
 } => ({
   type: AquamanStep.CLOSE,
 });
+
+/**
+ * Dispatch to trigger a desired flow. Use this to active a flow from
+ * a user action (instead of as a side effect of a state change).
+ *
+ * @param key Unique key of flow to be started (not the flowId).
+ * @param soft If `true`, flow will only be started if there are no
+ * other active flows (ie a "soft" force flow won't override an active
+ * flow, but a "hard" one will).
+ * @returns Redux action of type `__Aquaman_FORCE_FLOW__`
+ */
 export const aquamanForceFlow = (
   key: string,
-  soft?: boolean,
+  soft?: boolean
 ): {
   type: AquamanStep.FORCE_FLOW;
   key: string;

--- a/src/Branch.ts
+++ b/src/Branch.ts
@@ -1,6 +1,6 @@
-import { Branch, ActionSeries } from './Types';
+import { Branch, ActionSeries } from "./Types";
 
-/*
+/**
  * Use branch to generate conditional flows based off user actions.
  * Pass actionSeries arrays into branch. You can pass the index
  * of an actionSeries into `flow.next` to trigger that flow.
@@ -9,12 +9,14 @@ import { Branch, ActionSeries } from './Types';
  * would start calling `[flow2Step1, flow2Step2]` since it is at
  * index 1 for branch's args.
  */
-
 export function branch(...args: ActionSeries[]): Branch {
-  const branches = args.reduce((acc: { [key: number]: any }, curr: any, idx: number) => {
-    acc[idx] = curr;
-    return acc;
-  }, {});
+  const branches = args.reduce(
+    (acc: { [key: number]: any }, curr: any, idx: number) => {
+      acc[idx] = curr;
+      return acc;
+    },
+    {}
+  );
 
   return {
     __BRANCH__: true,

--- a/src/FlowExcluder.spec.js
+++ b/src/FlowExcluder.spec.js
@@ -1,16 +1,23 @@
 const { FlowExcluder } = require("./FlowExcluder");
 
 describe("FlowExcluder", () => {
-  const excluder = FlowExcluder([
-    ["first", "second", "third"],
-    ["fourth", "fifth"],
-    ["sixth", "second"],
-  ]);
+  test("empty flow excluder", () => {
+    const excluder = FlowExcluder([]);
+    excluder.setViewed("first");
 
-  excluder.setViewed("fourth");
-  excluder.setViewed("sixth");
+    expect(excluder.isExcluded("first")).toBeTruthy();
+  });
 
   test("excluder works as expected", () => {
+    const excluder = FlowExcluder([
+      ["first", "second", "third"],
+      ["fourth", "fifth"],
+      ["sixth", "second"],
+    ]);
+
+    excluder.setViewed("fourth");
+    excluder.setViewed("sixth");
+
     expect(excluder.isExcluded("first")).toBeFalsy();
     expect(excluder.isExcluded("second")).toBeTruthy();
     expect(excluder.isExcluded("third")).toBeFalsy();

--- a/src/FlowExcluder.spec.js
+++ b/src/FlowExcluder.spec.js
@@ -1,0 +1,22 @@
+const { FlowExcluder } = require("./FlowExcluder");
+
+describe("FlowExcluder", () => {
+  const excluder = FlowExcluder([
+    ["first", "second", "third"],
+    ["fourth", "fifth"],
+    ["sixth", "second"],
+  ]);
+
+  excluder.setViewed("fourth");
+  excluder.setViewed("sixth");
+
+  test("excluder works as expected", () => {
+    expect(excluder.isExcluded("first")).toBeFalsy();
+    expect(excluder.isExcluded("second")).toBeTruthy();
+    expect(excluder.isExcluded("third")).toBeFalsy();
+    expect(excluder.isExcluded("fourth")).toBeTruthy();
+    expect(excluder.isExcluded("fifth")).toBeTruthy();
+    expect(excluder.isExcluded("sixth")).toBeTruthy();
+    expect(excluder.isExcluded("seventh")).toBeFalsy();
+  });
+});

--- a/src/FlowExcluder.ts
+++ b/src/FlowExcluder.ts
@@ -3,26 +3,30 @@ export interface Excluder {
   isExcluded(flowId: string): boolean;
 }
 
-export function FlowExcluder(coexclusiveFlows: string[][]) {
+export function FlowExcluder(mutuallyExclusiveFlows: string[][]) {
   const viewed = new Set<string>();
-  const exclusions = setCoexclusives();
+  const exclusions = setMutuallyExclusives();
 
   function setViewed(flowId: string) {
+    if (!exclusions.has(flowId)) {
+      exclusions.set(flowId, new Set([flowId]));
+    }
+
     viewed.add(flowId);
   }
 
-  function setCoexclusives() {
+  function setMutuallyExclusives() {
     const map = new Map<string, Set<string>>();
 
-    for (const coexclusives of coexclusiveFlows) {
-      for (const flowId of coexclusives) {
+    for (const mutuallyExclusives of mutuallyExclusiveFlows) {
+      for (const flowId of mutuallyExclusives) {
         if (map.has(flowId)) {
           const set = map.get(flowId)!;
-          for (const val of coexclusives) {
+          for (const val of mutuallyExclusives) {
             set.add(val);
           }
         } else {
-          map.set(flowId, new Set(coexclusives));
+          map.set(flowId, new Set(mutuallyExclusives));
         }
       }
     }

--- a/src/FlowExcluder.ts
+++ b/src/FlowExcluder.ts
@@ -1,0 +1,53 @@
+export interface Excluder {
+  setViewed(flowId: string): void;
+  isExcluded(flowId: string): boolean;
+}
+
+export function FlowExcluder(coexclusiveFlows: string[][]) {
+  const viewed = new Set<string>();
+  const exclusions = setCoexclusives();
+
+  function setViewed(flowId: string) {
+    viewed.add(flowId);
+  }
+
+  function setCoexclusives() {
+    const map = new Map<string, Set<string>>();
+
+    for (const coexclusives of coexclusiveFlows) {
+      for (const flowId of coexclusives) {
+        if (map.has(flowId)) {
+          const set = map.get(flowId)!;
+          for (const val of coexclusives) {
+            set.add(val);
+          }
+        } else {
+          map.set(flowId, new Set(coexclusives));
+        }
+      }
+    }
+
+    return map;
+  }
+
+  function isExcluded(flowId: string) {
+    const excludors = exclusions.get(flowId);
+
+    if (!excludors) {
+      return false;
+    }
+
+    for (const val of excludors) {
+      if (viewed.has(val)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  return {
+    isExcluded,
+    setViewed,
+  };
+}

--- a/src/FlowStarter.ts
+++ b/src/FlowStarter.ts
@@ -21,7 +21,7 @@ const defaultReduxConfig = {
   shouldStartFlow: () => true,
   onWillChooseFlow: () => {},
   functionMap: {},
-  coexclusiveFlows: [],
+  mutuallyExclusiveFlows: [],
 };
 
 function toObserable(store: Store) {
@@ -51,7 +51,7 @@ export class FlowStarter {
       ...mapReduxToConfig(store, dispatch),
     };
 
-    this.excluder = FlowExcluder(this.config.coexclusiveFlows ?? []);
+    this.excluder = FlowExcluder(this.config.mutuallyExclusiveFlows ?? []);
 
     this.initializeFlow();
   }

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -6,7 +6,7 @@ import {
   compose,
   Reducer,
   StoreCreator,
-  Middleware
+  Middleware,
 } from "redux";
 import { FlowStarter } from "./FlowStarter";
 import { FlowObj, MapReduxToConfig, AquamanStep } from "./Types";
@@ -48,7 +48,10 @@ function AquamanMiddleware(
   };
 }
 
-function applyAquaman(aquamanMiddleware: Function, ...middlewares: Middleware[]) {
+function applyAquaman(
+  aquamanMiddleware: Function,
+  ...middlewares: Middleware[]
+) {
   return (createStore: StoreCreator) => <S, A extends AnyAction>(
     reducer: Reducer<S, A>,
     ...args: any[]
@@ -63,7 +66,7 @@ function applyAquaman(aquamanMiddleware: Function, ...middlewares: Middleware[])
 
     const middlewareAPI: MiddlewareAPI = {
       getState: store.getState,
-      dispatch: (action, ...args) => dispatch(action, ...args)
+      dispatch: (action, ...args) => dispatch(action, ...args),
     };
     const chain = middlewares.map((middleware: any) =>
       middleware(middlewareAPI)
@@ -71,23 +74,31 @@ function applyAquaman(aquamanMiddleware: Function, ...middlewares: Middleware[])
     chain.push(
       aquamanMiddleware({
         ...middlewareAPI,
-        subscribe: store.subscribe
+        subscribe: store.subscribe,
       })
     );
     dispatch = compose<typeof dispatch>(...chain)(store.dispatch);
 
     return {
       ...store,
-      dispatch
+      dispatch,
     };
   };
 }
 
+/**
+ * Use this to compose Aquaman middleware with the rest of your
+ * Redux middleware.
+ *
+ * @param flows array of flow objects
+ * @param mapReduxToConfig configuration object
+ * @returns Redux middleware
+ */
 export function applyAquamanAndMiddleware(
   flows: FlowObj[],
   mapReduxToConfig: MapReduxToConfig
 ): any {
-  return function(...middlewares: Middleware[]) {
+  return function (...middlewares: Middleware[]) {
     return applyAquaman(
       AquamanMiddleware(flows, mapReduxToConfig),
       ...middlewares

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -23,7 +23,7 @@ export interface AquamanConfig {
   shouldStartFlow: () => boolean | void;
   onWillChooseFlow: (flow: FlowObj) => FlowObj | false | void;
   functionMap: { [functionName: string]: Function };
-  coexclusiveFlows?: string[][];
+  mutuallyExclusiveFlows?: string[][];
 }
 
 export type AquamanConfigPartial = Partial<AquamanConfig>;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -23,6 +23,7 @@ export interface AquamanConfig {
   shouldStartFlow: () => boolean | void;
   onWillChooseFlow: (flow: FlowObj) => FlowObj | false | void;
   functionMap: { [functionName: string]: Function };
+  coexclusiveFlows?: string[][];
 }
 
 export type AquamanConfigPartial = Partial<AquamanConfig>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,5 +15,11 @@ export {
   MappedFunction,
 } from "./Types";
 import { AquamanStep } from "./Types";
+
+/**
+ * Use this in a multi-step action (an array within a series array) to
+ * end the flow when the last step of the flow doesn't have a UI element
+ * to it (and can't be aquamanNext-ed or aquamanClose-d out of).
+ */
 export const FORCE_END_MULTISTEP = AquamanStep.FORCE_END_MULTISTEP;
 export { FlowStarter } from "./FlowStarter";


### PR DESCRIPTION
Add flow excluder to prevent already seen flows from showing up, and to be able to configure flows that shouldn't show if another "coexcluded" flow has already been seen.