### PR TITLE
"shouldStartFlow" now receives the current flowId as an argument

### DIFF
--- a/src/FlowStarter.ts
+++ b/src/FlowStarter.ts
@@ -88,7 +88,7 @@ export class FlowStarter {
           filter(
             () =>
               !this.inProgress &&
-              !!this.config.shouldStartFlow() &&
+              !!this.config.shouldStartFlow(flow.flowId) &&
               !this.excluder.isExcluded(flow.flowId)
           )
         )

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -20,7 +20,7 @@ export interface AquamanConfig {
   persistSettings?: PersistSettings;
   onEndFlow: (flowId: string) => Promise<void>;
   onStep: () => void;
-  shouldStartFlow: () => boolean | void;
+  shouldStartFlow: (flowId: string) => boolean | void;
   onWillChooseFlow: (flow: FlowObj) => FlowObj | false | void;
   functionMap: { [functionName: string]: Function };
   mutuallyExclusiveFlows?: string[][];


### PR DESCRIPTION
`excludedFlows` is a new optional configuration property that prevents certain flows from running. This can be useful if you want to block a flow from running in a particular environment without polluting the flow condition.