### PR TITLE
Call "onStep" before "next"

### DIFF
--- a/src/FlowStarter.ts
+++ b/src/FlowStarter.ts
@@ -146,12 +146,11 @@ export class FlowStarter {
     const flowId = currentFlow?.getFlowId() ?? ''
 
     if (currentFlow) {
+      this.stepCount++;
+      this.config.onStep(flowId, this.stepCount);
       const done = currentFlow.next(data);
       if (done) {
         this.close();
-      } else {
-        this.stepCount++;
-        this.config.onStep(flowId, this.stepCount);
       }
     }
   };


### PR DESCRIPTION
In my previous PR, I changed the order of these. This can cause some unexpected behavior if you depend on calling "onStep" before going to to the next step.