### PR TITLE
EG-1478 Add isCompleted flag to onEndFlow

### DIFF
--- a/src/Aquaman.spec.js
+++ b/src/Aquaman.spec.js
@@ -236,7 +236,7 @@ describe("Aquaman", () => {
   });
 
   describe.skip("#next", () => {
-    it("will end the flow when called on last step of series", () => {
+    it("will end the flow with isCompleted=true when called on last step of series", () => {
       const flows = [
         {
           flowId: "default",
@@ -252,7 +252,7 @@ describe("Aquaman", () => {
       expect(onStep).toHaveBeenCalledTimes(2);
       expect(aquaman.inProgress).toBeFalsy;
       expect(onEndFlow).toHaveBeenCalledTimes(1);
-      expect(onEndFlow).toBeCalledWith("default");
+      expect(onEndFlow).toBeCalledWith("default", true);
     });
 
     it("can handle branching", () => {
@@ -470,6 +470,7 @@ describe("Aquaman", () => {
       aquaman.next();
 
       expect(onEndFlow).toHaveBeenCalledTimes(1);
+      expect(onEndFlow).toHaveBeenCalledWith("close");
       expect(dispatch).toHaveBeenCalledWith({ type: "step2" });
       expect(dispatch).not.toHaveBeenCalledWith({ type: "step3" });
     });

--- a/src/FlowStarter.ts
+++ b/src/FlowStarter.ts
@@ -192,7 +192,7 @@ export class FlowStarter {
       this.config.onStep(flowId, this.stepCount);
       const done = currentFlow.next(data);
       if (done) {
-        this.close();
+        this.close(true);
       }
     }
   };
@@ -207,12 +207,12 @@ export class FlowStarter {
     }
   };
 
-  close = async () => {
+  close = async (isCompleted?: boolean) => {
     const { currentFlow } = this;
     if (currentFlow) {
       const flowId = currentFlow.getFlowId();
       this.excluder.setViewed(flowId);
-      await this.config.onEndFlow(flowId);
+      await this.config.onEndFlow(flowId, isCompleted);
       this.inProgress = false;
       this.currentFlow = null;
       this.stepCount = 0;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -35,7 +35,7 @@ type OnWillChooseFlowWithOptions = (flow: FlowObj, flowOptions: FlowOptions) => 
 
 export interface AquamanConfig {
   persistSettings?: PersistSettings;
-  onEndFlow: (flowId: string) => Promise<void>;
+  onEndFlow: (flowId: string, isCompleted?: boolean) => Promise<void>;
   onStep: (flowId: string, stepCount: number) => void;
   shouldStartFlow: (flowId: string) => boolean | void;
   onWillChooseFlow: OnWillChooseFlow | OnWillChooseFlowWithOptions;


### PR DESCRIPTION
Adds `isCompleted` param to the `onEndFlow` callback when invoked from `next` with no more steps available.